### PR TITLE
Queue emotion updates during speech playback

### DIFF
--- a/tests/test_emotion_queue.py
+++ b/tests/test_emotion_queue.py
@@ -1,0 +1,28 @@
+import core.events as core_events
+from core.events import Event
+from emotion.manager import EmotionManager
+from emotion.state import Emotion
+
+
+def test_emotion_queue_during_speech():
+    core_events._subscribers.clear()
+    core_events._global_subscribers.clear()
+
+    mgr = EmotionManager()
+    events = []
+    core_events.subscribe("emotion_changed", lambda e: events.append(e.attrs["emotion"]))
+
+    mgr.start()
+    assert events == [Emotion.NEUTRAL]
+
+    core_events.publish(Event(kind="speech.synthesis_started"))
+    mgr._state.set(Emotion.HAPPY)
+    mgr._publish_emotion(Emotion.HAPPY)
+    assert events == [Emotion.NEUTRAL]
+
+    mgr._state.set(Emotion.SAD)
+    mgr._publish_emotion(Emotion.SAD)
+    assert events == [Emotion.NEUTRAL]
+
+    core_events.publish(Event(kind="speech.synthesis_finished"))
+    assert events == [Emotion.NEUTRAL, Emotion.SAD]

--- a/working_tts.py
+++ b/working_tts.py
@@ -19,6 +19,7 @@ from transliterate import translit  # type: ignore
 from threading import Event
 
 from core.nlp import numbers_to_words, remove_spaces_in_numbers
+from core import events as core_events
 
 # ────────────────────────── 0. LOGGING ────────────────────────────
 from core.logging_json import configure_logging
@@ -208,6 +209,9 @@ def working_tts(
     """Озвучивает *text*; при *save_wav* пишет итоговый WAV-файл."""
     global is_playing
     is_playing = True
+    core_events.publish(
+        core_events.Event(kind="speech.synthesis_started", attrs={"text": text})
+    )
     _STOP_EVENT.clear()
     # Приводим исходный текст к удобному для синтеза виду:
     # 1) числа → слова, 2) убираем пробелы в числах, 3) транслитерация
@@ -301,6 +305,7 @@ def working_tts(
     if save_wav:
         _save_wav(save_wav, full_audio)
     is_playing = False
+    core_events.publish(core_events.Event(kind="speech.synthesis_finished"))
     _STOP_EVENT.clear()
     sd.stop()
 


### PR DESCRIPTION
## Summary
- publish `speech.synthesis_*` events from TTS module
- delay emotion changes while speech is playing
- add regression test for emotion queueing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab2b3e6e588321801f29473cd83075