### PR TITLE
Coordinate Jarvis with M5 boot mode

### DIFF
--- a/JarvisM5/include/EnergyManager.h
+++ b/JarvisM5/include/EnergyManager.h
@@ -7,7 +7,6 @@ class EnergyManager {
 public:
     void begin() {
         lastActivity_ = millis();
-        M5.Display.setBrightness(20);
         screenDimmed_ = false;
     }
 

--- a/JarvisM5/include/UIMode.h
+++ b/JarvisM5/include/UIMode.h
@@ -1,0 +1,6 @@
+#pragma once
+
+enum class UIMode { Sleep, Boot, Run };
+
+void setUIMode(UIMode m);
+UIMode getUIMode();

--- a/JarvisM5/src/SerialClient.cpp
+++ b/JarvisM5/src/SerialClient.cpp
@@ -1,4 +1,5 @@
 #include "SerialClient.h"
+#include "UIMode.h"
 
 void SerialClient::begin(uint32_t baud) {
   Serial.begin(baud);
@@ -15,6 +16,10 @@ void SerialClient::loop() {
   if (millis() - lastHello_ > 2000) {
     sendEvent("hello", "ping");
     lastHello_ = millis();
+  }
+
+  if (!Serial.dtr()) {
+    ESP.restart();
   }
 
   while (Serial.available() > 0) {
@@ -64,6 +69,15 @@ void SerialClient::handleJson_(const String& s) {
   else if (!strcmp(kind, "emotion")) {
     const char* t = d["payload"] | "";
     em_.handle(t);
+  }
+  else if (!strcmp(kind, "mode")) {
+    const char* t = d["payload"] | "";
+    if (!strcmp(t, "boot"))
+      setUIMode(UIMode::Boot);
+    else if (!strcmp(t, "run"))
+      setUIMode(UIMode::Run);
+    else
+      setUIMode(UIMode::Sleep);
   }
   else if (strcmp(kind, "track") == 0) {
     const JsonObject p = d["payload"].as<JsonObject>();

--- a/JarvisM5/src/main.cpp
+++ b/JarvisM5/src/main.cpp
@@ -109,7 +109,6 @@ void loop() {
 
   switch (getUIMode()) {
     case UIMode::Sleep:
-      energy.update(false);
       return;
 
     case UIMode::Boot: {

--- a/JarvisM5/src/main.cpp
+++ b/JarvisM5/src/main.cpp
@@ -30,6 +30,8 @@ static UIMode uiMode = UIMode::Sleep;
 void setUIMode(UIMode m) {
   uiMode = m;
   if (m == UIMode::Sleep) {
+    // Ensure the backlight is fully off while waiting for the host
+    M5.Display.setBrightness(0);
     M5.Display.sleep();
   } else {
     M5.Display.wakeup();
@@ -50,7 +52,8 @@ void setup() {
   auto cfg = M5.config();
   cfg.clear_display = true;
   M5.begin(cfg);
-  M5.Display.setBrightness(20);
+  // Start with backlight off until the host tells us otherwise
+  M5.Display.setBrightness(0);
   frame.setColorDepth(8);
   frame.createSprite(320, 240);
   Logger::enableAutoPresent(false);

--- a/display/__init__.py
+++ b/display/__init__.py
@@ -17,7 +17,19 @@ from typing import Literal, Optional, Union
 
 @dataclass
 class DisplayItem:
-    kind:    Literal["text", "icon", "image", "rect", "line", "weather", "time", "emotion", "track", "frame"]
+    kind:    Literal[
+        "text",
+        "icon",
+        "image",
+        "rect",
+        "line",
+        "weather",
+        "time",
+        "emotion",
+        "track",
+        "frame",
+        "mode",
+    ]
     payload: Optional[Union[str, bytes, dict]]  # None → удалить элемент из кеша
 
 
@@ -51,7 +63,7 @@ class DisplayDriver(ABC):
 _driver: DisplayDriver | None = None
 
 
-def init_driver(name: str = "windows", driver: DisplayDriver | None = None) -> None:
+def init_driver(name: str = "windows", driver: DisplayDriver | None = None) -> DisplayDriver:
     """
     Инициализировать драйвер дисплея:
       - name: имя модуля внутри display.drivers (без .py)
@@ -61,10 +73,10 @@ def init_driver(name: str = "windows", driver: DisplayDriver | None = None) -> N
     """
     global _driver
     if _driver is not None:
-        return
+        return _driver
     if driver is not None:
         _driver = driver
-        return
+        return _driver
 
     # динамический импорт по имени
     module_path = f"display.drivers.{name}"
@@ -78,6 +90,7 @@ def init_driver(name: str = "windows", driver: DisplayDriver | None = None) -> N
         _driver.process_events()
     except Exception:
         pass
+    return _driver
 
 def get_driver() -> DisplayDriver:
     """Получить текущий драйвер, инициализировать по умолчанию, если не задан."""

--- a/start.py
+++ b/start.py
@@ -133,6 +133,8 @@ async def main() -> None:
                 reconnected = await asyncio.to_thread(driver.wait_ready, 5.0)
                 if reconnected:
                     continue
+                while working_tts.is_playing:
+                    await asyncio.sleep(0.1)
                 await asyncio.to_thread(
                     working_tts.working_tts,
                     "Дисплей был отключен, завершаю работу",

--- a/start.py
+++ b/start.py
@@ -162,7 +162,6 @@ async def main() -> None:
     model = vosk.Model('models/model_small')
     kaldi = vosk.KaldiRecognizer(model, 16000)
     recorder = PvRecorder(device_index=mic_idx, frame_length=512)
-    recorder.start()
 
     # 3. Приветственное сообщение (синхронно, чтобы не потерялось)
     await asyncio.to_thread(
@@ -172,6 +171,7 @@ async def main() -> None:
     )
     driver.draw(DisplayItem(kind="mode", payload="run"))
 
+    recorder.start()
     asyncio.create_task(gui_loop())
 
     log.info("Говорите команды, начиная с 'джарвис'")

--- a/start.py
+++ b/start.py
@@ -128,9 +128,15 @@ async def main() -> None:
         while True:
             await asyncio.sleep(1)
             if driver.disconnected.is_set():
+                log.warning("Display disconnected, waiting for reconnection")
+                # Даем M5 время на перезапуск и повторное рукопожатие
+                reconnected = await asyncio.to_thread(driver.wait_ready, 5.0)
+                if reconnected:
+                    continue
                 await asyncio.to_thread(
                     working_tts.working_tts,
-                    "Дисплей был отключен, завершаю работу", preset="neutral"
+                    "Дисплей был отключен, завершаю работу",
+                    preset="neutral",
                 )
                 sys.exit(0)
 


### PR DESCRIPTION
## Summary
- add `mode` display item so Jarvis can toggle M5 boot/run states
- drive M5 UI via boot/run modes and restart on host disconnect
- show boot logo and progress while Jarvis initializes

## Testing
- `pytest`
- ⚠️ `pio run` *(espressif32 platform installation stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3623eaf08321a6afba58e3120bcc