### PR TITLE
Add logging for event bus

### DIFF
--- a/core/events.py
+++ b/core/events.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 from dataclasses import dataclass, field
+import logging
 from typing import Any, Callable, Dict, List
 
 
@@ -21,6 +22,9 @@ _subscribers: Dict[str, List[Callable[[Event], None]]] = defaultdict(list)
 _global_subscribers: List[Callable[[Event], None]] = []
 
 
+log = logging.getLogger(__name__)
+
+
 def subscribe(kind: str, callback: Callable[[Event], None]) -> None:
     """Регистрирует обработчик *callback* для событий типа *kind*.
 
@@ -28,17 +32,20 @@ def subscribe(kind: str, callback: Callable[[Event], None]) -> None:
     """
 
     _subscribers[kind].append(callback)
+    log.debug("Subscribed %s to %s", getattr(callback, "__name__", repr(callback)), kind)
 
 
 def subscribe_all(callback: Callable[[Event], None]) -> None:
     """Регистрирует обработчик *callback* для всех событий."""
 
     _global_subscribers.append(callback)
+    log.debug("Subscribed %s to all events", getattr(callback, "__name__", repr(callback)))
 
 
 def publish(event: Event) -> None:
     """Публикует *event* для всех подписчиков."""
 
+    log.info("Publish event %s attrs=%s", event.kind, event.attrs)
     # Перебираем копию списка, чтобы подписчики могли отписаться внутри коллбэка
     for callback in list(_subscribers.get(event.kind, [])):
         callback(event)

--- a/tests/test_core_events_logging.py
+++ b/tests/test_core_events_logging.py
@@ -1,0 +1,39 @@
+import logging
+from core import events
+from core.events import Event
+
+
+def teardown_function():
+    events._subscribers.clear()
+    events._global_subscribers.clear()
+
+
+def test_subscribe_logs(caplog):
+    def handler(event: Event) -> None:
+        pass
+    with caplog.at_level(logging.DEBUG, logger="core.events"):
+        events.subscribe("kind", handler)
+    assert ("core.events", logging.DEBUG, "Subscribed handler to kind") in caplog.record_tuples
+
+
+def test_subscribe_all_logs(caplog):
+    def handler(event: Event) -> None:
+        pass
+    with caplog.at_level(logging.DEBUG, logger="core.events"):
+        events.subscribe_all(handler)
+    assert (
+        "core.events",
+        logging.DEBUG,
+        "Subscribed handler to all events",
+    ) in caplog.record_tuples
+
+
+def test_publish_logs(caplog):
+    evt = Event(kind="kind", attrs={"foo": "bar"})
+    with caplog.at_level(logging.INFO, logger="core.events"):
+        events.publish(evt)
+    assert (
+        "core.events",
+        logging.INFO,
+        "Publish event kind attrs={'foo': 'bar'}",
+    ) in caplog.record_tuples


### PR DESCRIPTION
## Summary
- log subscriber registration and event publishing in the core event bus
- add tests for event bus logging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac85edd3088321ba1e985ac129be6c