### PR TITLE
Add tests for voice/Telegram notifiers and M5 integration

### DIFF
--- a/tests/test_habits_aggregation.py
+++ b/tests/test_habits_aggregation.py
@@ -1,0 +1,22 @@
+import datetime as dt
+import time
+
+import memory.db as db
+from analysis import habits
+
+
+def test_aggregate_by_hour(monkeypatch, tmp_path):
+    db_file = tmp_path / "memory.sqlite3"
+    monkeypatch.setattr(db, "DB_PATH", db_file)
+
+    start = int(dt.datetime(2024, 1, 1, 23, 30).timestamp())
+    end = int(dt.datetime(2024, 1, 2, 1, 30).timestamp())
+    with db.get_connection() as conn:
+        conn.execute(
+            "INSERT INTO presence_sessions (start_ts, end_ts) VALUES (?, ?)",
+            (start, end),
+        )
+    counts = habits.aggregate_by_hour()
+    assert counts[23] == 30 * 60
+    assert counts[0] == 60 * 60
+    assert counts[1] == 30 * 60

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -1,0 +1,133 @@
+import asyncio
+import contextlib
+import importlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+
+class DummyResp:
+    def __init__(self, status_code=200, ok=True, text=""):
+        self.status_code = status_code
+        self._ok = ok
+        self.text = text
+
+    def json(self):
+        return {"ok": self._ok}
+
+
+def _load_telegram(monkeypatch):
+    cfg = SimpleNamespace(
+        telegram=SimpleNamespace(token="TOKEN"),
+        user=SimpleNamespace(telegram_user_id=123),
+    )
+    monkeypatch.setattr("core.config.load_config", lambda: cfg)
+    monkeypatch.delitem(sys.modules, "notifiers.telegram", raising=False)
+    import notifiers.telegram as telegram
+    return telegram
+
+
+def _load_voice(monkeypatch):
+    async def dummy_speak_async(text: str):
+        pass
+
+    dummy_module = SimpleNamespace(speak_async=dummy_speak_async)
+    monkeypatch.setitem(sys.modules, "working_tts", dummy_module)
+    monkeypatch.delitem(sys.modules, "notifiers.voice", raising=False)
+    import notifiers.voice as voice
+    return voice
+
+
+def test_telegram_notifier_send_success(monkeypatch):
+    telegram = _load_telegram(monkeypatch)
+    sent = {}
+
+    def fake_post(url, json, timeout):
+        sent["url"] = url
+        sent["json"] = json
+        return DummyResp()
+
+    metric_calls = {"count": 0}
+
+    def fake_inc_metric(name):
+        metric_calls["count"] += 1
+
+    monkeypatch.setattr(telegram.requests, "post", fake_post)
+    monkeypatch.setattr(telegram, "inc_metric", fake_inc_metric)
+
+    notifier = telegram.TelegramNotifier("TOKEN", 123)
+    notifier.send("hello")
+
+    assert metric_calls["count"] == 0
+    assert sent["url"].endswith("/sendMessage")
+    assert sent["json"] == {"chat_id": 123, "text": "hello"}
+
+
+def test_telegram_notifier_send_failure(monkeypatch):
+    telegram = _load_telegram(monkeypatch)
+
+    def fake_post(url, json, timeout):
+        raise requests.RequestException("boom")
+
+    metric_calls = {"count": 0}
+
+    def fake_inc_metric(name):
+        metric_calls["count"] += 1
+
+    monkeypatch.setattr(telegram.requests, "post", fake_post)
+    monkeypatch.setattr(telegram, "inc_metric", fake_inc_metric)
+
+    notifier = telegram.TelegramNotifier("TOKEN", 123)
+    notifier.send("hello")
+
+    assert metric_calls["count"] == 1
+
+
+def test_telegram_send_wrapper(monkeypatch):
+    telegram = _load_telegram(monkeypatch)
+    sent = []
+
+    class DummyNotifier:
+        def send(self, text):
+            sent.append(text)
+
+    monkeypatch.setattr(telegram, "_notifier", DummyNotifier())
+    telegram.send("hi")
+
+    assert sent == ["hi"]
+
+
+def test_voice_send_processes_queue(monkeypatch):
+    voice = _load_voice(monkeypatch)
+    spoken = []
+
+    async def fake_speak_async(text):
+        spoken.append(text)
+
+    async def run_test():
+        monkeypatch.setattr(voice, "speak_async", fake_speak_async)
+        monkeypatch.setattr(voice, "set_metric", lambda name, value: None)
+
+        # reset queue and worker state
+        voice._queue = asyncio.Queue()
+        if voice._worker_task is not None:
+            voice._worker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await voice._worker_task
+            voice._worker_task = None
+
+        voice.send("test")
+        assert voice._worker_task is not None
+
+        await asyncio.wait_for(voice._queue.join(), timeout=1)
+        assert spoken == ["test"]
+
+        # cancel worker task to clean up
+        voice._worker_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await voice._worker_task
+        voice._worker_task = None
+
+    asyncio.run(run_test())

--- a/tests/test_serial_display_driver.py
+++ b/tests/test_serial_display_driver.py
@@ -1,0 +1,52 @@
+import json
+import time
+import types
+
+from display import DisplayItem
+from display.drivers.serial import SerialDisplayDriver
+
+
+class DummySerial:
+    def __init__(self):
+        self.buffer = bytearray()
+        self.written = []
+        self.is_open = True
+
+    @property
+    def in_waiting(self):
+        return len(self.buffer)
+
+    def read(self, n):
+        if not self.buffer:
+            time.sleep(0.01)
+            return b""
+        chunk = self.buffer[:n]
+        del self.buffer[:n]
+        return bytes(chunk)
+
+    def write(self, data):
+        self.written.append(data.decode())
+
+    def close(self):
+        self.is_open = False
+
+    def feed(self, data: bytes):
+        self.buffer.extend(data)
+
+
+def test_serial_handshake_resends_cache(monkeypatch):
+    dummy = DummySerial()
+    fake_serial = types.SimpleNamespace(Serial=lambda *a, **k: dummy, SerialException=Exception)
+    monkeypatch.setattr("display.drivers.serial.serial", fake_serial)
+
+    driver = SerialDisplayDriver(port="dummy")
+    item = DisplayItem(kind="txt", payload="hi")
+    driver.draw(item)
+    dummy.written.clear()
+
+    dummy.feed(b'{"kind":"hello","payload":"ready"}\n')
+    assert driver.wait_ready(timeout=1.0)
+    time.sleep(0.1)
+    driver.close()
+
+    assert any(json.loads(w)["kind"] == "txt" for w in dummy.written)

--- a/tests/test_serial_display_driver.py
+++ b/tests/test_serial_display_driver.py
@@ -1,9 +1,9 @@
 import json
+import sys
 import time
 import types
 
 from display import DisplayItem
-from display.drivers.serial import SerialDisplayDriver
 
 
 class DummySerial:
@@ -37,7 +37,13 @@ class DummySerial:
 def test_serial_handshake_resends_cache(monkeypatch):
     dummy = DummySerial()
     fake_serial = types.SimpleNamespace(Serial=lambda *a, **k: dummy, SerialException=Exception)
-    monkeypatch.setattr("display.drivers.serial.serial", fake_serial)
+    fake_tools = types.SimpleNamespace(list_ports=types.SimpleNamespace(comports=lambda: []))
+    fake_serial.tools = fake_tools
+    monkeypatch.setitem(sys.modules, "serial", fake_serial)
+    monkeypatch.setitem(sys.modules, "serial.tools", fake_tools)
+    monkeypatch.setitem(sys.modules, "serial.tools.list_ports", fake_tools.list_ports)
+
+    from display.drivers.serial import SerialDisplayDriver
 
     driver = SerialDisplayDriver(port="dummy")
     item = DisplayItem(kind="txt", payload="hi")


### PR DESCRIPTION
## Summary
- test Telegram notifier success/failure and send wrapper
- test voice notifier queue processing with stubbed TTS
- verify M5 serial display handshake resends cached frames
- validate presence aggregation by hour across midnight

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac8bf84e9083218d87a9a4f67831d2