### PR TITLE
Scale up eyes by 50% and adjust spacing

### DIFF
--- a/JarvisM5/lib/esp32-eyes/Eye.cpp
+++ b/JarvisM5/lib/esp32-eyes/Eye.cpp
@@ -50,8 +50,20 @@ void Eye::Update() {
 }
 
 void Eye::Draw() {
-	Update();
-	EyeDrawer::Draw(CenterX, CenterY, FinalConfig);
+        Update();
+        constexpr float kEyeScale = 1.5f;
+        EyeConfig scaled = *FinalConfig;
+        scaled.OffsetX = static_cast<int16_t>(scaled.OffsetX * kEyeScale);
+        scaled.OffsetY = static_cast<int16_t>(scaled.OffsetY * kEyeScale);
+        scaled.Height  = static_cast<int16_t>(scaled.Height  * kEyeScale);
+        scaled.Width   = static_cast<int16_t>(scaled.Width   * kEyeScale);
+        scaled.Radius_Top = static_cast<int16_t>(scaled.Radius_Top * kEyeScale);
+        scaled.Radius_Bottom = static_cast<int16_t>(scaled.Radius_Bottom * kEyeScale);
+        scaled.Inverse_Radius_Top = static_cast<int16_t>(scaled.Inverse_Radius_Top * kEyeScale);
+        scaled.Inverse_Radius_Bottom = static_cast<int16_t>(scaled.Inverse_Radius_Bottom * kEyeScale);
+        scaled.Inverse_Offset_Top = static_cast<int16_t>(scaled.Inverse_Offset_Top * kEyeScale);
+        scaled.Inverse_Offset_Bottom = static_cast<int16_t>(scaled.Inverse_Offset_Bottom * kEyeScale);
+        EyeDrawer::Draw(CenterX, CenterY, &scaled);
 }
 
 void Eye::ApplyPreset(const EyeConfig config) {

--- a/JarvisM5/lib/esp32-eyes/Face.cpp
+++ b/JarvisM5/lib/esp32-eyes/Face.cpp
@@ -20,12 +20,13 @@ You should have received a copy of the GNU Affero General Public License along w
 Face::Face(uint16_t screenWidth, uint16_t screenHeight, uint16_t eyeSize) 
 	: LeftEye(*this), RightEye(*this), Blink(*this), Look(*this), Behavior(*this), Expression(*this) {
 
-	Width = screenWidth;
-	Height = screenHeight;
-	EyeSize = eyeSize;
+        Width = screenWidth;
+        Height = screenHeight;
+        EyeSize = eyeSize;
+        EyeInterDistance = eyeSize / 15;
 
-	CenterX = Width / 2;
-	CenterY = Height / 2;
+        CenterX = Width / 2;
+        CenterY = Height / 2;
 
 	LeftEye.IsMirrored = true;
 

--- a/JarvisM5/src/main.cpp
+++ b/JarvisM5/src/main.cpp
@@ -20,7 +20,7 @@ LGFX_Sprite frame(&M5.Display);
 #include <Ticker.h>
 
 Overlay       overlay;
-FaceWrapper   face(320, 240, 60);
+FaceWrapper   face(320, 240, 90);
 Emotion       emotion(face);
 ServoController servo;
 SerialClient ser(overlay, emotion, servo);


### PR DESCRIPTION
## Summary
- Enlarge rendered eyes by 50% via scaling of final configuration
- Derive inter-eye distance from overall eye size to keep proportions
- Initialize display face with larger eye size

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad44085a688321b733cd3c2347ea57