### PR TITLE
Ensure Telegram replies execute via main event loop

### DIFF
--- a/app/command_processing.py
+++ b/app/command_processing.py
@@ -12,7 +12,8 @@ from typing import Any, Dict, List
 import asyncio
 from rapidfuzz import fuzz
 
-from jarvis_skills import handle_utterance
+import jarvis_skills
+handle_utterance = jarvis_skills.handle_utterance
 from core.nlp import normalize
 from working_tts import speak_async
 from core.request_source import get_request_source
@@ -153,6 +154,11 @@ async def va_respond(voice: str) -> bool:
     cmd = extract_cmd(voice)
     if not cmd:
         return False
+    # Сохраняем текущий event loop, чтобы jarvis_skills мог
+    # безопасно отправлять ответы из побочного потока.
+    getattr(jarvis_skills, "set_main_loop", lambda loop: None)(
+        asyncio.get_running_loop()
+    )
     # handle_utterance может блокировать, поэтому вызываем в отдельном потоке
     if await asyncio.to_thread(handle_utterance, cmd):
         return True

--- a/tests/test_jarvis_skills.py
+++ b/tests/test_jarvis_skills.py
@@ -40,3 +40,41 @@ def test_handle_utterance_uses_voice_notifier_for_telegram(monkeypatch):
         reset_request_source(token)
 
     assert sent == [("ответ", "telegram")]
+
+
+def test_handle_utterance_from_thread(monkeypatch):
+    """Проверка, что отправка ответа из побочного потока работает корректно."""
+
+    import types, sys, asyncio
+
+    fake_nlp = types.SimpleNamespace(normalize=lambda s: s)
+    monkeypatch.setitem(sys.modules, "core.nlp", fake_nlp)
+
+    import jarvis_skills
+
+    sent: list[str] = []
+
+    def fake_send(text: str, *, pitch=None, speed=None, emotion=None):
+        sent.append(text)
+
+    fake_voice = types.SimpleNamespace(send=fake_send)
+    monkeypatch.setitem(sys.modules, "notifiers.voice", fake_voice)
+
+    def fake_skill(text: str) -> str:
+        return "ответ"
+
+    monkeypatch.setattr(jarvis_skills, "_loaded", [(["тест"], fake_skill)])
+
+    token = set_request_source("telegram")
+
+    async def run():
+        jarvis_skills.set_main_loop(asyncio.get_running_loop())
+        await asyncio.to_thread(jarvis_skills.handle_utterance, "тест")
+        await asyncio.sleep(0)
+
+    try:
+        asyncio.run(run())
+    finally:
+        reset_request_source(token)
+
+    assert sent == ["ответ"]


### PR DESCRIPTION
## Summary
- Route skill responses to the main event loop if called from threads
- Store main loop reference and expose handle_utterance in command processing
- Test thread-safe skill handling for Telegram commands

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade65fdb248321a1bd212373991678