### PR TITLE
Implement mood sensor abstractions with time-of-day example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ db.set_mood({"level": 10})
 
 Для обратной совместимости доступны функции `get_mood_level`, `set_mood_level`, `get_mood_state`, `set_mood_state`, однако внутри они используют новый универсальный API.
 
+### Сенсоры настроения
+
+Система поддерживает подключаемые **сенсоры настроения**, позволяющие
+изменять валентность и возбуждённость в зависимости от внешних факторов.
+Базовый класс `MoodSensor` упрощает интеграцию таких источников данных.
+
+```python
+from emotion.mood import Mood
+from emotion.sensors import TimeOfDayMoodSensor
+
+mood = Mood.load()
+sensor = TimeOfDayMoodSensor(mood)
+sensor.read_and_update()
+```
+
+В комплект входит `TimeOfDayMoodSensor`, повышающий настроение утром и
+снижающий вечером. Чтобы создать свой сенсор, унаследуйтесь от
+`MoodSensor` и реализуйте метод `measure`, возвращающий дельты настроения.
+
 ## Требования к оборудованию
 
 - Raspberry Pi 4 или новее

--- a/emotion/sensors.py
+++ b/emotion/sensors.py
@@ -1,0 +1,100 @@
+"""Абстракции сенсоров настроения и их примерные реализации.
+
+Модуль предоставляет базовый класс :class:`MoodSensor`, который
+упрощает интеграцию различных источников данных с системой эмоций.
+Каждый сенсор отвечает за вычисление дельт по осям ``valence`` и
+``arousal`` и применяет их к объекту :class:`emotion.mood.Mood`.
+
+Сенсоры можно вызывать периодически из планировщика или любого
+другого места приложения.  Для примера показан сенсор времени суток,
+который повышает настроение утром и понижает вечером.
+"""
+
+from __future__ import annotations
+
+# Стандартные библиотеки
+import abc
+import datetime as _dt
+import logging
+from typing import Callable, Tuple
+
+from emotion.mood import Mood
+
+# Логгер верхнего уровня для всех сенсоров настроения
+log = logging.getLogger("emotion.sensors")
+
+
+class MoodSensor(abc.ABC):
+    """Абстрактный базовый класс для сенсоров настроения.
+
+    Наследники должны переопределить метод :meth:`measure`, который
+    возвращает кортеж ``(valence_delta, arousal_delta, reason)``.
+    Метод :meth:`read_and_update` обрабатывает результат измерения и
+    при необходимости обновляет переданный объект настроения.
+    """
+
+    def __init__(self, mood: Mood, name: str) -> None:
+        self._mood = mood
+        self._name = name
+        self._logger = logging.getLogger(f"emotion.sensors.{name}")
+
+    # ------------------------------------------------------------------ utils
+    @abc.abstractmethod
+    def measure(self) -> Tuple[float, float, str]:
+        """Выполнить измерение и вернуть дельты настроения.
+
+        Возвращается кортеж ``(valence_delta, arousal_delta, reason)``.
+        Дельты могут быть нулевыми, тогда настроение не будет изменено.
+        """
+
+    # ----------------------------------------------------------------- main API
+    def read_and_update(self) -> None:
+        """Считать данные с сенсора и при необходимости обновить настроение."""
+
+        valence_delta, arousal_delta, reason = self.measure()
+        ctx = {
+            "sensor": self._name,
+            "valence_delta": valence_delta,
+            "arousal_delta": arousal_delta,
+            "reason": reason,
+        }
+        if valence_delta or arousal_delta:
+            # Изменение настроения фиксируем в информационном логе
+            self._logger.info("mood adjusted", extra={"ctx": ctx})
+            self._mood.update(valence_delta, arousal_delta)
+            # Сохранение в БД делаем отдельно для упрощения тестирования
+            self._mood.save()
+        else:
+            # Нулевые дельты полезны для диагностики
+            self._logger.debug("no mood change", extra={"ctx": ctx})
+
+
+class TimeOfDayMoodSensor(MoodSensor):
+    """Простейший сенсор, корректирующий настроение по времени суток.
+
+    Утром значения ``valence`` и ``arousal`` повышаются, днём остаются
+    неизменными, а вечером и ночью снижаются.  Такой сенсор может быть
+    полезен для имитации естественных суточных колебаний настроения.
+    """
+
+    def __init__(
+        self,
+        mood: Mood,
+        clock: Callable[[], _dt.datetime] | None = None,
+    ) -> None:
+        super().__init__(mood, "time_of_day")
+        # ``clock`` позволяет внедрять контроль времени в тестах
+        self._clock = clock or _dt.datetime.now
+
+    def measure(self) -> Tuple[float, float, str]:
+        """Рассчитать влияние текущего времени суток на настроение."""
+
+        hour = self._clock().hour
+        if 6 <= hour < 12:
+            # Утро – лёгкий подъём
+            return 0.2, 0.3, "morning"
+        if 12 <= hour < 18:
+            # Днём настроение не меняем
+            return 0.0, 0.0, "afternoon"
+        # Вечером настроение слегка падает
+        return -0.2, -0.3, "night"

--- a/tests/emotion/test_mood_sensors.py
+++ b/tests/emotion/test_mood_sensors.py
@@ -1,0 +1,54 @@
+import datetime as _dt
+
+from emotion.mood import Mood
+from emotion.sensors import TimeOfDayMoodSensor
+
+
+def _make_cfg(tmp_path):
+    """Создать конфигурацию без сглаживания для точных тестов."""
+    cfg = tmp_path / "affect.yaml"
+    cfg.write_text("valence_factor: 1\narousal_factor: 1\nema_alpha: 1\n", encoding="utf-8")
+    return cfg
+
+
+def test_morning_increases_mood(tmp_path, monkeypatch):
+    """Утром настроение должно повышаться."""
+    cfg = _make_cfg(tmp_path)
+    mood = Mood(valence=0.0, arousal=0.0, config_path=cfg)
+    # Запрещаем обращение к реальной БД
+    monkeypatch.setattr(mood, "save", lambda trace_id=None: None)
+
+    sensor = TimeOfDayMoodSensor(mood, clock=lambda: _dt.datetime(2024, 1, 1, 8, 0, 0))
+    sensor.read_and_update()
+
+    assert mood.valence == 0.2
+    assert mood.arousal == 0.3
+
+
+def test_noon_no_change(tmp_path, monkeypatch):
+    """Днём сенсор не должен менять настроение."""
+    cfg = _make_cfg(tmp_path)
+    mood = Mood(valence=0.0, arousal=0.0, config_path=cfg)
+    monkeypatch.setattr(mood, "save", lambda trace_id=None: None)
+    calls: list[tuple[float, float]] = []
+    monkeypatch.setattr(mood, "update", lambda v, a, trace_id=None: calls.append((v, a)))
+
+    sensor = TimeOfDayMoodSensor(mood, clock=lambda: _dt.datetime(2024, 1, 1, 15, 0, 0))
+    sensor.read_and_update()
+
+    assert calls == []
+    assert mood.valence == 0.0
+    assert mood.arousal == 0.0
+
+
+def test_night_decreases_mood(tmp_path, monkeypatch):
+    """Вечером и ночью настроение понижается."""
+    cfg = _make_cfg(tmp_path)
+    mood = Mood(valence=0.0, arousal=0.0, config_path=cfg)
+    monkeypatch.setattr(mood, "save", lambda trace_id=None: None)
+
+    sensor = TimeOfDayMoodSensor(mood, clock=lambda: _dt.datetime(2024, 1, 1, 22, 0, 0))
+    sensor.read_and_update()
+
+    assert mood.valence == -0.2
+    assert mood.arousal == -0.3


### PR DESCRIPTION
## Summary
- add abstract `MoodSensor` base class with structured logging
- implement `TimeOfDayMoodSensor` for morning/evening mood shifts
- document mood sensors and usage in README
- add tests covering new sensor behavior

## Testing
- `PYTHONPATH=. pytest tests/emotion/test_mood_sensors.py tests/emotion/test_mood_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c135acc7e083218aee22f19e93b107