### PR TITLE
Refactor mood system to use unified object API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,20 +46,20 @@ Jarvis-Pi — русскоязычный офлайн голосовой асс�
 
 ## Настроение ассистента
 
-Эмоциональное состояние хранится в SQLite как структура `{"valence": float, "arousal": float, "level": int}`. Такой формат облегчает анализ и генерацию ответов.
+Эмоциональное состояние хранится в SQLite как структура `{"valence": float, "arousal": float}`. Такой формат облегчает анализ и генерацию ответов.
 
 ```python
 from memory import db
 
 # Чтение текущего настроения
 mood = db.get_mood()
-print(mood["valence"], mood["arousal"], mood["level"])
+print(mood["valence"], mood["arousal"])
 
 # Частичное обновление значений
-db.set_mood({"level": 10})
+db.set_mood({"valence": 0.5})
 ```
 
-Для обратной совместимости доступны функции `get_mood_level`, `set_mood_level`, `get_mood_state`, `set_mood_state`, однако внутри они используют новый универсальный API.
+Все операции выполняются через единый API `set_mood`/`get_mood`; устаревшие функции удалены после миграции.
 
 ### Сенсоры настроения
 

--- a/emotion/manager.py
+++ b/emotion/manager.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 # Локальные модули системы эмоций
 from emotion.state import EmotionState, Emotion
-from emotion.mood import Mood
 from emotion import policy
 
 import config  # глобальные настройки приложения
@@ -38,9 +37,6 @@ class EmotionManager:
         self._state = EmotionState()
         self._prev_emotion = self._state.current
 
-        # Объект настроения (valence/arousal), восстанавливаемый из БД
-        self._mood = Mood.load()
-
         # Признак текущего присутствия пользователя перед камерой
         self._present = True
         # Активен ли сейчас обработчик пользовательского запроса
@@ -68,7 +64,7 @@ class EmotionManager:
         core_events.subscribe("presence.update", self._on_presence_update)
         core_events.subscribe("speech.synthesis_started", self._on_speech_started)
         core_events.subscribe("speech.synthesis_finished", self._on_speech_finished)
-        # Уровень настроения зависит от успешности диалога
+        # Настроение зависит от успешности диалога
         core_events.subscribe("dialog.success", self._on_dialog_success)
         core_events.subscribe("dialog.failure", self._on_dialog_failure)
         # Внешние факторы, влияющие на настроение (например, погода)
@@ -130,7 +126,6 @@ class EmotionManager:
     def _on_dialog_success(self, event: core_events.Event) -> None:
         """Реакция на успешный ответ пользователю."""
         # Поднимаем числовой уровень настроения для обратной совместимости
-        self._state.raise_mood(reason="dialog success")
         # Обновляем двухмерное настроение и выбираем новую эмоцию
         self._update_mood(1.0, 1.0, reason="dialog success")
         # Генерация и озвучивание «муд‑профиля» через LLM при разрешённой конфигурацией озвучке
@@ -141,7 +136,6 @@ class EmotionManager:
 
     def _on_dialog_failure(self, event: core_events.Event) -> None:
         """Реакция на ошибку или непонимание команды."""
-        self._state.drop_mood(reason="dialog failure")
         # Снижаем валентность сильнее, чем возбуждение, чтобы перейти в негативную зону
         self._update_mood(-2.0, 0.5, reason="dialog failure")
         # Озвучивание настроения выключаем, если параметр отключён в конфигурации
@@ -315,17 +309,18 @@ class EmotionManager:
         Вызывает политику выбора эмоций и сохраняет состояние в БД.
         ``reason`` используется для подробного логирования вклада события.
         """
-        self._mood.update(valence_delta, arousal_delta)
-        self._mood.save()
+        # Изменяем координаты настроения через объект ``Mood`` из ``EmotionState``
+        self._state.mood.update(valence_delta, arousal_delta)
+        self._state.mood.save()
         log.info(
             "mood update (%s) valence=%+.2f arousal=%+.2f → (%.2f, %.2f)",
             reason,
             valence_delta,
             arousal_delta,
-            self._mood.valence,
-            self._mood.arousal,
+            self._state.mood.valence,
+            self._state.mood.arousal,
         )
-        policy_res = policy.select(self._mood.valence, self._mood.arousal)
+        policy_res = policy.select(self._state.mood.valence, self._state.mood.arousal)
         emotion = self._policy_icon_to_emotion(policy_res.icon)
         self._switch_emotion(emotion, reason, policy_res)
 
@@ -351,7 +346,12 @@ class EmotionManager:
             profile = ""
 
         # Сохраняем текст и координаты настроения в отдельной таблице
-        db.add_mood_history(self._mood.valence, self._mood.arousal, source, profile)
+        db.add_mood_history(
+            self._state.mood.valence,
+            self._state.mood.arousal,
+            source,
+            profile,
+        )
 
         # Отправляем сообщение в TTS с учётом текущего пресета
         try:

--- a/emotion/state.py
+++ b/emotion/state.py
@@ -1,9 +1,15 @@
+"""Модуль управления текущей эмоцией и настроением."""
+
+from __future__ import annotations
+
+# Стандартные библиотеки
 import random
 import time
 from enum import Enum
 
+# Внутренние модули
 from core.logging_json import configure_logging
-from memory import db
+from emotion.mood import Mood
 
 
 class Emotion(Enum):
@@ -29,23 +35,13 @@ class Emotion(Enum):
 
 
 class EmotionState:
-    """
-    Управляет текущим состоянием эмоции и логикой переходов.
-    """
+    """Управляет текущей эмоцией и двухмерным настроением."""
 
-    #: Максимально возможный уровень настроения
-    _MAX_MOOD = 100
-    #: Минимально возможный уровень настроения
-    _MIN_MOOD = -100
-
-    def __init__(self):
+    def __init__(self) -> None:
         # Текущая «видимая» эмоция персонажа
         self.current = Emotion.NEUTRAL
-        # Числовой уровень настроения [-100;100]. При запуске
-        # восстанавливаем его из постоянного хранилища, чтобы Jarvis
-        # помнил предыдущее состояние между перезапусками.
-        # Загружаем числовой уровень настроения из единого хранилища
-        self.mood = db.get_mood()["level"]
+        # Объект ``Mood`` восстанавливается из БД и хранит valence/arousal
+        self.mood: Mood = Mood.load()
         # Инициализируем логгер для удобной отладки.
         self._log = configure_logging("emotion.state")
 
@@ -59,34 +55,54 @@ class EmotionState:
     # ------------------------------------------------------------------
 
     def _save_mood(self) -> None:
-        """Сохранить текущее значение настроения в БД."""
-        # Сохраняем только уровень, не затрагивая valence/arousal
-        db.set_mood({"level": self.mood})
+        """Сохранить текущее состояние ``Mood`` в БД."""
 
-    def raise_mood(self, delta: int = 10, reason: str = "") -> int:
-        """Повысить настроение на ``delta`` и вернуть новое значение.
+        # Используем встроенный метод ``save``, который записывает valence
+        # и arousal в хранилище. Дополнительные поля отсутствуют.
+        self.mood.save()
 
-        Значение всегда ограничивается диапазоном ``[-100; 100]``.
-        В лог выводится причина изменения, что помогает анализировать
-        реакцию ассистента на взаимодействие с пользователем.
+    def raise_mood(self, delta: int = 10, reason: str = "") -> tuple[float, float]:
+        """Повысить настроение и вернуть новые координаты.
+
+        Параметр ``delta`` задаётся в условных единицах и преобразуется в
+        изменение валентности/возбуждения по шкале [-1.0; 1.0].  Метод
+        вызывает :py:meth:`Mood.update`, затем сохраняет результат и
+        выводит подробный лог для удобной отладки.
         """
-        prev = self.mood
-        self.mood = min(self._MAX_MOOD, self.mood + delta)
+
+        step = delta / 100.0
+        before = self.mood.as_tuple()
+        self.mood.update(step, step)
         self._save_mood()
-        self._log.info("mood %s → %s (%s)", prev, self.mood, reason)
-        return self.mood
+        after = self.mood.as_tuple()
+        self._log.info(
+            "mood %s → %s (%s)",
+            before,
+            after,
+            reason,
+        )
+        return after
 
-    def drop_mood(self, delta: int = 10, reason: str = "") -> int:
-        """Понизить настроение на ``delta`` и вернуть новое значение.
+    def drop_mood(self, delta: int = 10, reason: str = "") -> tuple[float, float]:
+        """Понизить настроение и вернуть новые координаты.
 
-        Значение всегда ограничивается диапазоном ``[-100; 100]``.
-        Логирование аналогично ``raise_mood``.
+        Значение ``delta`` преобразуется в отрицательные дельты и передаётся
+        в :py:meth:`Mood.update`.  Это обеспечивает единый API управления
+        настроением.
         """
-        prev = self.mood
-        self.mood = max(self._MIN_MOOD, self.mood - delta)
+
+        step = delta / 100.0
+        before = self.mood.as_tuple()
+        self.mood.update(-step, -step)
         self._save_mood()
-        self._log.info("mood %s → %s (%s)", prev, self.mood, reason)
-        return self.mood
+        after = self.mood.as_tuple()
+        self._log.info(
+            "mood %s → %s (%s)",
+            before,
+            after,
+            reason,
+        )
+        return after
 
     def get_time_based_emotion(self, hour: int | None = None) -> Emotion:
         """Выбрать базовую эмоцию в зависимости от времени суток.

--- a/memory/db.py
+++ b/memory/db.py
@@ -344,9 +344,10 @@ PRIORITIES_KEY = "reflection:priorities"
 
 
 def get_mood(trace_id: str | None = None) -> dict:
-    """Вернуть текущее настроение ``{valence, arousal, level}``.
+    """Вернуть текущее настроение ``{valence, arousal}``.
 
-    Если данные хранятся в старом формате, выполняется миграция.
+    При необходимости выполняется миграция со старого формата, где
+    использовалось поле ``level`` и отдельный ключ ``emotion:mood_state``.
     """
 
     start = time.time()
@@ -356,23 +357,22 @@ def get_mood(trace_id: str | None = None) -> dict:
             "SELECT value FROM context_items WHERE key=?", (MOOD_KEY,)
         ).fetchone()
 
-    mood: dict[str, float | int]
+    mood: dict[str, float]
     if row:
         try:
             data = json.loads(row["value"])
             if not isinstance(data, dict):
                 raise TypeError
         except (json.JSONDecodeError, TypeError):
-            # В старом формате под ключом хранится просто число уровня
+            # В старом формате под ключом хранилось число уровня
             data = {"level": int(row["value"]) if row["value"] else 0}
             migrated = True
         mood = {
             "valence": float(data.get("valence", 0.0)),
             "arousal": float(data.get("arousal", 0.0)),
-            "level": int(data.get("level", 0)),
         }
     else:
-        mood = {"valence": 0.0, "arousal": 0.0, "level": 0}
+        mood = {"valence": 0.0, "arousal": 0.0}
 
     if migrated or row is None or any(k not in data for k in ("valence", "arousal")):
         with get_connection() as conn:
@@ -404,7 +404,6 @@ def get_mood(trace_id: str | None = None) -> dict:
                 "duration_ms": duration,
                 "valence": mood["valence"],
                 "arousal": mood["arousal"],
-                "level": mood["level"],
                 "migrated": migrated,
             },
             ensure_ascii=False,
@@ -434,7 +433,6 @@ def set_mood(mood: dict, trace_id: str | None = None) -> None:
     normalized = {
         "valence": float(current.get("valence", 0.0)),
         "arousal": float(current.get("arousal", 0.0)),
-        "level": int(current.get("level", 0)),
     }
     _store_mood(normalized)
     with get_connection() as conn:
@@ -451,34 +449,10 @@ def set_mood(mood: dict, trace_id: str | None = None) -> None:
                 "duration_ms": duration,
                 "valence": normalized["valence"],
                 "arousal": normalized["arousal"],
-                "level": normalized["level"],
             },
             ensure_ascii=False,
         )
     )
-
-
-# Обратная совместимость ---------------------------------------------------
-
-def get_mood_level() -> int:  # pragma: no cover - простая обёртка
-    """Вернуть уровень настроения (устаревший интерфейс)."""
-    return int(get_mood()["level"])
-
-
-def set_mood_level(level: int) -> None:  # pragma: no cover - простая обёртка
-    """Сохранить уровень настроения (устаревший интерфейс)."""
-    set_mood({"level": level})
-
-
-def get_mood_state(trace_id: str | None = None) -> tuple[float, float]:
-    """Вернуть координаты настроения (устаревший интерфейс)."""
-    mood = get_mood(trace_id=trace_id)
-    return float(mood["valence"]), float(mood["arousal"])
-
-
-def set_mood_state(valence: float, arousal: float, trace_id: str | None = None) -> None:
-    """Сохранить координаты настроения (устаревший интерфейс)."""
-    set_mood({"valence": valence, "arousal": arousal}, trace_id=trace_id)
 
 def set_priorities(priorities: str) -> None:
     """Сохранить список приоритетов на следующий день."""

--- a/tests/test_emotion_mood_state.py
+++ b/tests/test_emotion_mood_state.py
@@ -19,14 +19,14 @@ def test_mood_db_persistence(tmp_path, monkeypatch):
     db_file = tmp_path / "memory.sqlite3"
     monkeypatch.setattr(db, "DB_PATH", db_file)
 
-    db.set_mood({"valence": 0.3, "arousal": -0.7, "level": 2}, trace_id="save")
+    db.set_mood({"valence": 0.3, "arousal": -0.7}, trace_id="save")
     mood = db.get_mood(trace_id="load")
 
-    assert mood == {"valence": 0.3, "arousal": -0.7, "level": 2}
+    assert mood == {"valence": 0.3, "arousal": -0.7}
 
 
 def test_mood_migration_and_legacy(tmp_path, monkeypatch):
-    """Миграция старого формата и работа устаревших обёрток."""
+    """Миграция со старых ключей и форматов значения настроения."""
     db_file = tmp_path / "memory.sqlite3"
     monkeypatch.setattr(db, "DB_PATH", db_file)
 
@@ -41,19 +41,10 @@ def test_mood_migration_and_legacy(tmp_path, monkeypatch):
             (db._LEGACY_MOOD_STATE_KEY, "{\"valence\":0.1,\"arousal\":-0.2}"),
         )
 
-    # Первый вызов должен мигрировать данные
+    # Первый вызов должен мигрировать данные и вернуть новую структуру
     mood = db.get_mood()
-    assert mood == {"valence": 0.1, "arousal": -0.2, "level": 5}
+    assert mood == {"valence": 0.1, "arousal": -0.2}
 
-    # Проверяем обёртки
-    assert db.get_mood_level() == 5
-    valence, arousal = db.get_mood_state()
-    assert valence == 0.1
-    assert arousal == -0.2
-
-    db.set_mood_level(7)
-    assert db.get_mood()["level"] == 7
-
-    db.set_mood_state(0.5, 0.6)
-    v, a = db.get_mood_state()
-    assert (v, a) == (0.5, 0.6)
+    # Повторный вызов не должен изменять данные
+    mood2 = db.get_mood()
+    assert mood2 == mood

--- a/tests/test_emotion_persistent_mood.py
+++ b/tests/test_emotion_persistent_mood.py
@@ -12,7 +12,8 @@ def setup_function(function):
 
 
 def test_emotion_persistent_mood(monkeypatch, tmp_path):
-    """Сохранение и восстановление уровня настроения между перезапусками."""
+    """Сохранение и восстановление настроения между перезапусками."""
+
     monkeypatch.setitem(
         sys.modules,
         "working_tts",
@@ -20,8 +21,18 @@ def test_emotion_persistent_mood(monkeypatch, tmp_path):
     )
     import emotion.manager as mgr_module
     monkeypatch.setattr(mgr_module, "is_day_off", lambda day=None: (False, None))
+
+    # Избавляемся от сглаживания настроения для предсказуемых результатов
+    import emotion.mood as mood
+
+    def fake_load_config(self):
+        self._valence_factor = 1.0
+        self._arousal_factor = 1.0
+        self._ema_alpha = 1.0
+
+    monkeypatch.setattr(mood.Mood, "_load_config", fake_load_config)
+
     from emotion.manager import EmotionManager
-    from emotion.state import Emotion
 
     db_file = tmp_path / "memory.sqlite3"
     monkeypatch.setattr(db, "DB_PATH", db_file)
@@ -30,28 +41,28 @@ def test_emotion_persistent_mood(monkeypatch, tmp_path):
     core_events.subscribe("emotion_changed", lambda e: None)
     mgr.start()
 
-    # Эмулируем серию успешных запросов
+    # Эмулируем серию успешных запросов → настроение уходит в максимум
     for _ in range(3):
         core_events.publish(Event(kind="dialog.success"))
-    assert mgr._state.mood == 30
+    assert mgr._state.mood.as_tuple() == (1.0, 1.0)
 
     # Новый экземпляр должен восстановить настроение из БД
     core_events._subscribers.clear()
     core_events._global_subscribers.clear()
     mgr2 = EmotionManager()
-    assert mgr2._state.mood == 30
+    assert mgr2._state.mood.as_tuple() == (1.0, 1.0)
 
-    # Теперь имитируем ошибки
+    # Теперь имитируем ошибки → валентность становится отрицательной
     core_events.subscribe("emotion_changed", lambda e: None)
     for _ in range(2):
         core_events.publish(Event(kind="dialog.failure"))
-    assert mgr2._state.mood == 10
+    assert mgr2._state.mood.as_tuple() == (-1.0, 1.0)
 
     # После очередного "перезапуска" значение должно сохраниться
     core_events._subscribers.clear()
     core_events._global_subscribers.clear()
     mgr3 = EmotionManager()
-    assert mgr3._state.mood == 10
+    assert mgr3._state.mood.as_tuple() == (-1.0, 1.0)
 
     # Останавливаем менеджеры, чтобы фоновые таймеры не мешали другим тестам
     mgr.stop()


### PR DESCRIPTION
## Summary
- replace numeric mood level with Mood object and route mood changes through `Mood.update`
- consolidate EmotionManager on shared mood state
- migrate database schema to drop legacy mood fields and update docs/tests

## Testing
- `pytest tests/test_emotion_mood_state.py tests/test_emotion_persistent_mood.py tests/test_emotion_manager_reactions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c13e6ad5e08321a7b9c1f7e42deeb6