### PR TITLE
Add dialog logging service with metadata enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,38 @@ export JARVIS_DB_KEY=$(python -c "from cryptography.fernet import Fernet;print(F
 python -m memory.dialogs --limit 50 --channel telegram
 ```
 
+Для программного доступа используйте сервис `memory.dialog_log`. Он
+гарантирует генерацию `trace_id` и автоматически обогащает метаданные
+каналом, пользователем и статусом доставки. Унифицированный API
+облегчает отладку и построение аналитики.
+
+```python
+from memory.dialog_log import record_dialog_message, get_dialog_history
+
+trace = "support-1"
+record_dialog_message(
+    "Принял задачу",
+    direction="incoming",
+    channel="telegram",
+    user_id=12345,
+    trace_id=trace,
+    metadata={"ticket": "OPS-42"},
+)
+
+history = get_dialog_history(trace_id=trace)
+for item in history:
+    print(item.ts, item.direction, item.meta["status"], item.text)
+```
+
+### Локальное тестирование
+
+```bash
+pytest tests/memory -q
+```
+
+Набор тестов проверяет запись, выборку и обогащение метаданными,
+обеспечивая воспроизводимый аудит истории диалогов.
+
 Утилита выводит канал (`voice` или `telegram`), направление (`incoming` или
 `outgoing`) и `trace_id`, что позволяет быстро находить связанные события в
 логах. Доступны фильтры по `trace_id`, каналу и сортировка (`--asc`), поэтому

--- a/app/command_processing.py
+++ b/app/command_processing.py
@@ -25,7 +25,7 @@ from core import events as core_events
 from core.request_source import get_request_source
 from memory.writer import add_suggestion_feedback
 from memory.db import get_connection
-from memory.dialogs import log_message
+from memory.dialog_log import record_dialog_message
 from proactive.engine import (
     is_awaiting_response,
     pop_awaiting,
@@ -36,6 +36,31 @@ from context import daily_memory  # Дневная память для конс�
 
 # Инициализируем модульный логгер, чтобы отслеживать процесс разбора команд.
 log = configure_logging("app.command_processing")
+
+_TELEGRAM_USER_ID: str | int | None = None
+
+
+def _resolve_default_user(channel: str) -> str | int:
+    """Определить идентификатор пользователя по каналу."""
+
+    global _TELEGRAM_USER_ID
+    if channel == "voice":
+        return "voice-user"
+    if channel == "telegram":
+        if _TELEGRAM_USER_ID is None:
+            try:
+                from core.config import load_config
+
+                cfg = load_config()
+                _TELEGRAM_USER_ID = getattr(cfg.user, "telegram_user_id", "telegram-user")
+                log.debug(
+                    "resolved telegram user id", extra={"ctx": {"user_id": _TELEGRAM_USER_ID}}
+                )
+            except Exception:
+                _TELEGRAM_USER_ID = "telegram-user"
+                log.exception("failed to resolve telegram user id")
+        return _TELEGRAM_USER_ID
+    return f"{channel}-user"
 
 
 def _ensure_trace_id() -> tuple[str, Token | None]:
@@ -50,23 +75,46 @@ def _ensure_trace_id() -> tuple[str, Token | None]:
     return trace, token
 
 
-def _log_dialog(direction: str, text: str, channel: str, trace_id: str, meta: dict[str, Any] | None = None) -> None:
-    """Безопасно записать сообщение в журнал диалогов."""
+def _log_dialog(
+    direction: str,
+    text: str,
+    channel: str,
+    trace_id: str,
+    meta: dict[str, Any] | None = None,
+    user_id: str | int | None = None,
+    status: str | None = None,
+) -> None:
+    """Безопасно записать сообщение в журнал диалогов через сервис."""
 
     if not text:
         return
+    metadata = dict(meta or {})
+    if user_id is None and "user_id" in metadata:
+        user_id = metadata.pop("user_id")
+    if status is None and "status" in metadata:
+        status = metadata.pop("status")
     try:
-        log_message(
+        record_dialog_message(
             text,
             direction=direction,
             channel=channel,
             trace_id=trace_id,
-            metadata=meta,
+            user_id=user_id or _resolve_default_user(channel),
+            status=status,
+            metadata=metadata,
         )
     except Exception:
         log.exception(
             "failed to log dialog message",
-            extra={"ctx": {"direction": direction, "channel": channel, "trace_id": trace_id}},
+            extra={
+                "ctx": {
+                    "direction": direction,
+                    "channel": channel,
+                    "trace_id": trace_id,
+                    "user_id": user_id,
+                    "status": status,
+                }
+            },
         )
 
 # ────────────────────────── КОНСТАНТЫ ──────────────────────────────

--- a/memory/dialog_log.py
+++ b/memory/dialog_log.py
@@ -1,0 +1,202 @@
+"""Сервисный слой для централизованного журнала диалогов."""
+
+from __future__ import annotations
+
+from contextvars import Token
+from dataclasses import dataclass
+from typing import Any
+
+from core.logging_json import TRACE_ID, configure_logging, new_trace_id
+from memory import dialogs
+
+# Инициализируем отдельный логгер, чтобы в журналах можно было увидеть
+# движение сообщений без включения глобального дебага. Подробные записи
+# помогают анализировать сложные сценарии в боевом окружении.
+log = configure_logging("memory.dialog_log")
+
+
+@dataclass(frozen=True)
+class DialogRecord:
+    """Описывает одно сообщение диалога, возвращаемое из сервиса."""
+
+    id: int
+    text: str
+    direction: str
+    channel: str
+    trace_id: str
+    meta: dict[str, Any]
+    ts: int
+
+
+_DEFAULT_STATUS = {
+    "incoming": "received",
+    "outgoing": "sent",
+}
+
+
+def _default_user(channel: str) -> str:
+    """Вернуть идентификатор пользователя по каналу при его отсутствии."""
+
+    if channel == "voice":
+        return "voice-user"
+    if channel == "telegram":
+        return "telegram-user"
+    return f"{channel}-user"
+
+
+def _ensure_trace(trace_id: str | None) -> tuple[str, Token | None]:
+    """Убедиться, что в контексте есть ``trace_id``, и вернуть его."""
+
+    current = TRACE_ID.get()
+    if trace_id:
+        if current == trace_id:
+            return trace_id, None
+        token = TRACE_ID.set(trace_id)
+        log.debug("use provided trace id", extra={"ctx": {"trace_id": trace_id}})
+        return trace_id, token
+    if current:
+        return current, None
+    generated = new_trace_id()
+    token = TRACE_ID.set(generated)
+    log.debug("generated trace id in dialog service", extra={"ctx": {"trace_id": generated}})
+    return generated, token
+
+
+def _build_metadata(
+    *,
+    channel: str,
+    user_id: str | int | None,
+    status: str | None,
+    extra: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Объединить обязательные и пользовательские метаданные."""
+
+    meta: dict[str, Any] = {"channel": channel}
+    if user_id is not None:
+        meta["user_id"] = str(user_id)
+    if status:
+        meta["status"] = status
+    if extra:
+        for key, value in extra.items():
+            if value is not None:
+                meta[key] = value
+    return meta
+
+
+def record_dialog_message(
+    text: str,
+    *,
+    direction: str,
+    channel: str,
+    user_id: str | int | None = None,
+    status: str | None = None,
+    trace_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> tuple[int, str]:
+    """Сохранить сообщение в журнале и вернуть его ID вместе с ``trace_id``."""
+
+    trace, token = _ensure_trace(trace_id)
+    effective_status = status or _DEFAULT_STATUS.get(direction, "unknown")
+    resolved_user = user_id if user_id is not None else _default_user(channel)
+    payload_meta = _build_metadata(
+        channel=channel,
+        user_id=resolved_user,
+        status=effective_status,
+        extra=metadata,
+    )
+    log.debug(
+        "record dialog message",
+        extra={
+            "ctx": {
+                "trace_id": trace,
+                "direction": direction,
+                "channel": channel,
+                "user_id": resolved_user,
+                "status": effective_status,
+            }
+        },
+    )
+    try:
+        message_id = dialogs.log_message(
+            text,
+            direction=direction,
+            channel=channel,
+            trace_id=trace,
+            metadata=payload_meta,
+        )
+    finally:
+        if token is not None:
+            TRACE_ID.reset(token)
+    if message_id == -1:
+        log.error(
+            "dialog message was not stored",
+            extra={"ctx": {"trace_id": trace, "direction": direction, "channel": channel}},
+        )
+    else:
+        log.debug(
+            "dialog message stored",
+            extra={"ctx": {"id": message_id, "trace_id": trace, "direction": direction}},
+        )
+    return message_id, trace
+
+
+def _normalize_history_entry(item: dict[str, Any]) -> DialogRecord:
+    """Преобразовать строку БД в удобный объект ``DialogRecord``."""
+
+    meta = dict(item.get("meta") or {})
+    meta.setdefault("channel", item.get("channel"))
+    if "user_id" in meta and meta["user_id"] is not None:
+        meta["user_id"] = str(meta["user_id"])
+    meta.setdefault("status", _DEFAULT_STATUS.get(item.get("direction"), "unknown"))
+    meta.setdefault("user_id", _default_user(item.get("channel", "unknown")))
+    return DialogRecord(
+        id=int(item["id"]),
+        text=item.get("text", ""),
+        direction=item.get("direction", ""),
+        channel=item.get("channel", ""),
+        trace_id=item.get("trace_id", ""),
+        meta=meta,
+        ts=int(item["ts"]),
+    )
+
+
+def get_dialog_history(
+    *,
+    limit: int = 50,
+    channel: str | None = None,
+    direction: str | None = None,
+    trace_id: str | None = None,
+    ascending: bool = False,
+) -> list[DialogRecord]:
+    """Получить историю сообщений с возможностью фильтрации."""
+
+    trace, token = _ensure_trace(trace_id)
+    log.debug(
+        "fetch dialog history",
+        extra={
+            "ctx": {
+                "trace_id": trace,
+                "limit": limit,
+                "channel": channel,
+                "direction": direction,
+                "ascending": ascending,
+            }
+        },
+    )
+    try:
+        rows = dialogs.fetch_history(
+            limit=limit,
+            channel=channel,
+            direction=direction,
+            trace_id=trace,
+            ascending=ascending,
+        )
+    finally:
+        if token is not None:
+            TRACE_ID.reset(token)
+    records = [_normalize_history_entry(row) for row in rows]
+    log.debug(
+        "history fetched",
+        extra={"ctx": {"trace_id": trace, "returned": len(records)}},
+    )
+    return records

--- a/notifiers/telegram.py
+++ b/notifiers/telegram.py
@@ -12,7 +12,7 @@ from core.logging_json import configure_logging, TRACE_ID
 from core.metrics import inc_metric, set_metric
 from core.config import load_config
 from utils.reply import extract_reply
-from memory.dialogs import log_message
+from memory.dialog_log import record_dialog_message
 
 log = configure_logging("notifiers.telegram")
 # Счётчик неудачных попыток отправки сообщений.
@@ -57,17 +57,37 @@ class TelegramNotifier:
             if resp.status_code != 200 or not data.get("ok", False):
                 log.warning("telegram api error: %s %s", resp.status_code, resp.text)
                 inc_metric("telegram.failures")
-            else:
-                log_message(
+                record_dialog_message(
                     clean,
                     direction="outgoing",
                     channel="telegram",
                     trace_id=TRACE_ID.get(),
+                    user_id=_cfg.user.telegram_user_id,
+                    status="failed",
+                    metadata={"reason": data.get("description", "api_error")},
+                )
+            else:
+                record_dialog_message(
+                    clean,
+                    direction="outgoing",
+                    channel="telegram",
+                    trace_id=TRACE_ID.get(),
+                    user_id=_cfg.user.telegram_user_id,
+                    status="delivered",
                 )
         except (requests.RequestException, ValueError) as exc:
             # Сеть недоступна или получен некорректный JSON.
             log.warning("telegram request failed: %s", exc)
             inc_metric("telegram.failures")
+            record_dialog_message(
+                clean,
+                direction="outgoing",
+                channel="telegram",
+                trace_id=TRACE_ID.get(),
+                user_id=_cfg.user.telegram_user_id,
+                status="failed",
+                metadata={"reason": "exception", "error": str(exc)},
+            )
 
     def send_action(self, action: str = "typing") -> None:
         """Отправить пользователю индикатор действия.

--- a/notifiers/telegram_listener.py
+++ b/notifiers/telegram_listener.py
@@ -22,7 +22,7 @@ from core.logging_json import configure_logging, TRACE_ID, new_trace_id
 from core.metrics import inc_metric, set_metric
 from core.request_source import set_request_source, reset_request_source
 from core import events as core_events
-from memory.dialogs import fetch_history
+from memory.dialog_log import get_dialog_history, record_dialog_message
 
 # ────────────────────────── ИНИЦИАЛИЗАЦИЯ ──────────────────────────
 
@@ -30,6 +30,31 @@ from memory.dialogs import fetch_history
 log = configure_logging("notifiers.telegram_listener")
 # Публикуем метрику количества входящих сообщений.
 set_metric("telegram.incoming", 0)
+
+
+def _log_control_dialog(
+    text: str,
+    *,
+    direction: str,
+    status: str,
+    command: str,
+) -> None:
+    """Записать сообщение служебной команды в журнал диалогов."""
+
+    try:
+        record_dialog_message(
+            text,
+            direction=direction,
+            channel="telegram",
+            user_id=_USER_ID,
+            status=status,
+            metadata={"kind": "control", "command": command},
+        )
+    except Exception:
+        log.exception(
+            "failed to log control dialog",
+            extra={"ctx": {"direction": direction, "command": command}},
+        )
 
 
 def _validate_config(cfg: Any) -> None:
@@ -112,7 +137,7 @@ def _format_uptime(seconds: float) -> str:
 def _render_history(limit: int) -> str:
     """Формируем текст с последними сообщениями диалога."""
 
-    history = fetch_history(limit=limit, channel="telegram", ascending=False)
+    history = get_dialog_history(limit=limit, channel="telegram", ascending=False)
     if not history:
         return "История пуста — пока не о чем рассказывать."
 
@@ -120,9 +145,9 @@ def _render_history(limit: int) -> str:
     # Записи уже отсортированы по убыванию времени; разворачиваем, чтобы
     # выводить в естественном порядке от старых к новым.
     for item in reversed(history):
-        direction = "→" if item["direction"] == "outgoing" else "←"
-        timestamp = datetime.fromtimestamp(item["ts"]).strftime("%H:%M:%S")
-        text = item["text"].strip() or "(пусто)"
+        direction = "→" if item.direction == "outgoing" else "←"
+        timestamp = datetime.fromtimestamp(item.ts).strftime("%H:%M:%S")
+        text = item.text.strip() or "(пусто)"
         lines.append(f"{timestamp} {direction} {text}")
     return "\n".join(lines)
 
@@ -139,6 +164,7 @@ def _handle_control_command(text: str) -> bool:
     log.debug("control command received: %s args=%s", name, args)
 
     if name in {"/start", "/help"}:
+        _log_control_dialog(clean, direction="incoming", status="received", command=name)
         help_text = (
             "Привет! Доступные команды:\n"
             "• /help — подсказка по возможностям\n"
@@ -147,9 +173,11 @@ def _handle_control_command(text: str) -> bool:
             "Просто напиши сообщение, и я выполню команду или отвечу."
         )
         _send_telegram_message(help_text)
+        _log_control_dialog(help_text, direction="outgoing", status="delivered", command=name)
         return True
 
     if name == "/status":
+        _log_control_dialog(clean, direction="incoming", status="received", command=name)
         uptime = _format_uptime(time.time() - _STARTED_AT)
         status = (
             "Ассистент активен.\n"
@@ -158,19 +186,29 @@ def _handle_control_command(text: str) -> bool:
             f"Очередь long polling: {'активна' if _RUNNING else 'остановлена'}"
         )
         _send_telegram_message(status)
+        _log_control_dialog(status, direction="outgoing", status="delivered", command=name)
         return True
 
     if name == "/history":
+        _log_control_dialog(clean, direction="incoming", status="received", command=name)
         default_limit = 10
         limit = default_limit
         if args:
             try:
                 limit = max(1, min(50, int(args[0])))
             except ValueError:
-                _send_telegram_message("Нужно указать число от 1 до 50.")
+                error = "Нужно указать число от 1 до 50."
+                _send_telegram_message(error)
+                _log_control_dialog(error, direction="outgoing", status="failed", command=name)
                 return True
         history_text = _render_history(limit)
         _send_telegram_message(history_text)
+        _log_control_dialog(
+            history_text,
+            direction="outgoing",
+            status="delivered",
+            command=name,
+        )
         return True
 
     log.debug("unknown control command: %s", name)

--- a/notifiers/voice.py
+++ b/notifiers/voice.py
@@ -12,7 +12,7 @@ from core.metrics import inc_metric, set_metric
 from core.request_source import get_request_source
 from working_tts import speak_async
 from utils.reply import extract_reply
-from memory.dialogs import log_message
+from memory.dialog_log import record_dialog_message
 
 log = configure_logging("notifiers.voice")
 
@@ -103,13 +103,17 @@ def say(text: str, *, pitch: float | None = None, speed: float | None = None, em
     )
     set_metric("tts.queue_len", _queue.qsize())
     if source == "voice":
-        log_message(
-            clean,
-            direction="outgoing",
-            channel="voice",
-            trace_id=TRACE_ID.get(),
-            metadata={"emotion": emotion, "pitch": pitch, "speed": speed},
-        )
+        try:
+            record_dialog_message(
+                clean,
+                direction="outgoing",
+                channel="voice",
+                trace_id=TRACE_ID.get(),
+                status="queued",
+                metadata={"emotion": emotion, "pitch": pitch, "speed": speed},
+            )
+        except Exception:  # pragma: no cover - защита от сбоев БД
+            log.exception("failed to log voice notification")
 
 
 def send(

--- a/tests/memory/conftest.py
+++ b/tests/memory/conftest.py
@@ -1,0 +1,23 @@
+"""Общие фикстуры для модулей тестирования памяти."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from memory import db as memory_db
+
+
+@pytest.fixture()
+def dialog_db(monkeypatch, tmp_path):
+    """Создаёт временную SQLite-базу для тестирования журнала диалога."""
+
+    monkeypatch.setenv("JARVIS_DB_KEY", Fernet.generate_key().decode())
+    db_file = tmp_path / "memory.sqlite3"
+    monkeypatch.setattr(memory_db, "DB_PATH", db_file)
+    return db_file

--- a/tests/memory/test_dialog_log_service.py
+++ b/tests/memory/test_dialog_log_service.py
@@ -1,0 +1,56 @@
+"""Тесты сервисного слоя для журнала диалогов."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from memory.dialog_log import get_dialog_history, record_dialog_message
+
+
+def test_record_dialog_message_enriches_metadata(dialog_db):
+    """Проверяем, что сервис добавляет обязательные метаданные."""
+
+    trace = "trace-service"
+    message_id, stored_trace = record_dialog_message(
+        "Привет",
+        direction="incoming",
+        channel="telegram",
+        user_id=12345,
+        trace_id=trace,
+        metadata={"purpose": "unit"},
+    )
+    assert message_id > 0
+    assert stored_trace == trace
+
+    history = get_dialog_history(trace_id=trace, channel="telegram")
+    assert len(history) == 1
+    entry = history[0]
+    assert entry.meta["channel"] == "telegram"
+    assert entry.meta["user_id"] == "12345"
+    assert entry.meta["status"] == "received"
+    assert entry.meta["purpose"] == "unit"
+
+
+def test_record_dialog_message_generates_trace(dialog_db):
+    """При отсутствии trace_id сервис генерирует его автоматически."""
+
+    message_id, trace = record_dialog_message(
+        "Ответ",
+        direction="outgoing",
+        channel="voice",
+        status="delivered",
+        metadata={"emotion": "neutral"},
+    )
+    assert message_id > 0
+    assert trace
+
+    history = get_dialog_history(trace_id=trace, channel="voice")
+    assert history
+    entry = history[0]
+    assert entry.meta["status"] == "delivered"
+    assert entry.meta["channel"] == "voice"
+    assert entry.meta["emotion"] == "neutral"
+    assert entry.meta["user_id"] == "voice-user"

--- a/tests/memory/test_dialog_logging.py
+++ b/tests/memory/test_dialog_logging.py
@@ -3,22 +3,7 @@ import asyncio
 from pathlib import Path
 import sys
 
-from cryptography.fernet import Fernet
-
-import pytest
-
 sys.path.append(str(Path(__file__).resolve().parents[2]))
-
-from memory import db as memory_db
-
-
-@pytest.fixture()
-def dialog_db(monkeypatch, tmp_path):
-    monkeypatch.setenv("JARVIS_DB_KEY", Fernet.generate_key().decode())
-    db_file = tmp_path / "memory.sqlite3"
-    monkeypatch.setattr(memory_db, "DB_PATH", db_file)
-    return db_file
-
 
 def test_log_and_fetch_history(dialog_db):
     from memory import dialogs


### PR DESCRIPTION
## Summary
- add a dedicated dialog logging service that automatically handles trace ids and metadata
- wire the new service into command processing, Telegram listener, and notifiers with richer logging
- document the API in the README and cover it with focused tests

## Testing
- pytest tests/memory -q

------
https://chatgpt.com/codex/tasks/task_e_68ce5849870083218ee7e4bf551f86c1